### PR TITLE
fix(PluginFrame): add /sd prefix in getSettings path for SD plugins

### DIFF
--- a/src/components/PluginFrame.tsx
+++ b/src/components/PluginFrame.tsx
@@ -159,7 +159,8 @@ export function PluginFrame({ plugin, onClose, inline }: { plugin: Plugin; onClo
           reply(useMachineStore.getState().controllerSettings); break
         case 'getSettings': {
           const fs = plugin.fs
-          fetchFileContent(`/plugins/${plugin.id}/settings.json`, fs)
+          const prefix = fs === 'sd' ? '/sd' : ''
+          fetchFileContent(`${prefix}/plugins/${plugin.id}/settings.json`, fs)
             .then(text => reply(JSON.parse(text)))
             .catch(() => reply({}))
           break


### PR DESCRIPTION
fetchFileContent does not add the /sd prefix automatically
getSettings was requesting /plugins/<id>/settings.json (404)
instead of /sd/plugins/<id>/settings.json for SD-installed plugins.