### PR TITLE
Show running G-code source line during job playback

### DIFF
--- a/src/components/GCodeTextPanel.tsx
+++ b/src/components/GCodeTextPanel.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+const LINE_HEIGHT_PX = 18
+const MAX_LINE_ROWS = 20000
+
+interface Props {
+  text: string | null
+  loading?: boolean
+  activeLine: number | null
+  followActiveLine?: boolean
+  className?: string
+}
+
+function activeRowClass(isActive: boolean) {
+  return isActive
+    ? 'bg-accent/30 border-l-[3px] border-accent shadow-[inset_0_0_0_1px_rgba(var(--accent-rgb),0.25)]'
+    : 'border-l-[3px] border-transparent hover:bg-elevated/60'
+}
+
+export function GCodeTextPanel({
+  text,
+  loading = false,
+  activeLine,
+  followActiveLine = true,
+  className = '',
+}: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const activeLineRef = useRef<HTMLDivElement>(null)
+  const lines = useMemo(() => (text ? text.split('\n') : []), [text])
+  const useLineRows = lines.length > 0 && lines.length <= MAX_LINE_ROWS
+
+  useEffect(() => {
+    if (!followActiveLine || activeLine == null) return
+    const row = activeLineRef.current
+    if (row) {
+      row.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      return
+    }
+    const container = scrollRef.current
+    if (container && !useLineRows) {
+      container.scrollTop = Math.max(0, (activeLine - 1) * LINE_HEIGHT_PX - container.clientHeight / 2)
+    }
+  }, [activeLine, followActiveLine, useLineRows, text])
+
+  return (
+    <div className={`flex flex-col min-h-0 bg-bg ${className}`}>
+      <div className="shrink-0 px-3 py-1.5 border-b border-border text-[11px] uppercase tracking-wide text-text-muted font-semibold flex items-center justify-between gap-2">
+        <span>G-code</span>
+        {activeLine != null && (
+          <span className="normal-case tracking-normal font-mono text-accent text-[10px]">
+            Line {activeLine}
+          </span>
+        )}
+      </div>
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto">
+        {loading && (
+          <div className="p-3 text-sm text-text-muted">Loading source…</div>
+        )}
+        {!loading && !text && (
+          <div className="p-3 text-sm text-text-muted">
+            No source text available. Load a file to view G-code here.
+          </div>
+        )}
+        {!loading && text && useLineRows && (
+          <div className="py-1 font-mono text-[11px] leading-[18px]">
+            {lines.map((line, index) => {
+              const lineNo = index + 1
+              const isActive = activeLine === lineNo
+              return (
+                <div
+                  key={lineNo}
+                  ref={isActive ? activeLineRef : undefined}
+                  className={`flex gap-2 px-2 ${activeRowClass(isActive)}`}
+                >
+                  <span className={`w-9 shrink-0 text-right tabular-nums select-none ${isActive ? 'text-accent font-bold' : 'text-text-dim'}`}>
+                    {lineNo}
+                  </span>
+                  <span className={`flex-1 min-w-0 whitespace-pre-wrap break-all ${isActive ? 'text-text-primary font-semibold' : 'text-text-primary'}`}>
+                    {line || ' '}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+        {!loading && text && !useLineRows && (
+          <div className="relative py-1">
+            {activeLine != null && (
+              <div
+                aria-hidden="true"
+                className="absolute left-0 right-0 bg-accent/30 border-l-[3px] border-accent pointer-events-none z-0"
+                style={{
+                  top: `${(activeLine - 1) * LINE_HEIGHT_PX + 4}px`,
+                  height: `${LINE_HEIGHT_PX}px`,
+                }}
+              />
+            )}
+            <pre className="relative z-[1] px-3 font-mono text-[11px] leading-[18px] whitespace-pre-wrap break-all text-text-primary">
+              {text}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/GCodeViewer.tsx
+++ b/src/components/GCodeViewer.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { Eye, Axis3D, Maximize2, Crosshair, Navigation, Play, Pause, Square, CloudDrizzle, Waves, PowerOff, Box, Zap, Orbit, Hand } from 'lucide-react'
-import { type GCodeModel, type Segment } from '../lib/gcode'
+import { type GCodeModel, type Segment, resolveRunningSourceLine } from '../lib/gcode'
 import { useMachineStore } from '../store'
 import { useGCodeStore } from '../store/gcode'
 import { sendRaw, sendRealtime } from '../lib/ws'
@@ -1433,6 +1433,7 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
   const is3DToggleDisabled = pendingPath !== null || isProcessing2D || (!!model && !is3DReady)
   const [autoFollow, setAutoFollow] = useState(true)
   const [coolantState, setCoolantState] = useState<'off' | 'mist' | 'flood'>('off')
+  const [currentSourceLine, setCurrentSourceLine] = useState<number | null>(null)
 
   // Keep refs in sync so render() (called from non-React contexts) reads current values
   showRapidsRef.current = showRapids
@@ -1797,6 +1798,15 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
     } else {
       progressRef.current = null
     }
+    if (isRunning && modelRef.current) {
+      setCurrentSourceLine(resolveRunningSourceLine(
+        modelRef.current,
+        progressRef.current?.segmentIndex ?? null,
+        status.sdPercent,
+      ))
+    } else {
+      setCurrentSourceLine(null)
+    }
     prevIsRunningRef.current = isRunning
     prevModelRef.current = model
 
@@ -1815,6 +1825,7 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
     status.wpos.z,
     status.wco.x,
     status.wco.y,
+    status.sdPercent,
     controllerSettings.maxTravelX,
     controllerSettings.maxTravelY,
     controllerSettings.homingDirInvert,
@@ -2348,6 +2359,11 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
         {/* Progress bar — only while a job is active */}
         {(isJobRunning || isJobHeld) && (
           <div className="flex flex-col gap-1.5">
+            {currentSourceLine != null && (
+              <div className="text-[11px] font-mono text-text-muted tabular-nums">
+                Line {currentSourceLine}{model?.sourceLineCount ? ` / ${model.sourceLineCount}` : ''}
+              </div>
+            )}
             {progressPercent != null && (
               <div className="flex items-center gap-2.5">
                 <div className="flex-1 h-1.5 bg-elevated rounded-full overflow-hidden">

--- a/src/components/GCodeViewer.tsx
+++ b/src/components/GCodeViewer.tsx
@@ -1,9 +1,10 @@
-import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
-import { Eye, Axis3D, Maximize2, Crosshair, Navigation, Play, Pause, Square, CloudDrizzle, Waves, PowerOff, Box, Zap, Orbit, Hand } from 'lucide-react'
-import { type GCodeModel, type Segment, resolveRunningSourceLine } from '../lib/gcode'
+import { useRef, useEffect, useLayoutEffect, useState, useCallback, useMemo } from 'react'
+import { Eye, Axis3D, Maximize2, Crosshair, Navigation, Play, Pause, Square, CloudDrizzle, Waves, PowerOff, Box, Zap, Orbit, Hand, FileText } from 'lucide-react'
+import { type GCodeModel, type Segment, resolveRunningSourceLine, buildSourceLineIndex } from '../lib/gcode'
 import { useMachineStore } from '../store'
 import { useGCodeStore } from '../store/gcode'
 import { sendRaw, sendRealtime } from '../lib/ws'
+import { GCodeTextPanel } from './GCodeTextPanel'
 import type { ControllerSettings, MachineStatus, Units } from '../types'
 import { displayToMm, mmToDisplay } from '../lib/units'
 import { formatRuntime, useJobRuntimeEstimate } from '../lib/jobRuntime'
@@ -754,6 +755,44 @@ function findToolpathProgress(
   return previous
 }
 
+/** Conservative progress for line-number display — advances one segment at a time. */
+function findLineToolpathProgress(
+  segments: Segment[],
+  px: number,
+  py: number,
+  previous: ToolpathProgress | null,
+): ToolpathProgress | null {
+  if (segments.length === 0) return null
+  if (!previous) return { segmentIndex: 0, fraction: 0 }
+
+  const toleranceSq = FOLLOW_TOLERANCE_MM ** 2
+  const current = segments[previous.segmentIndex]
+  const onCurrent = measureProgressAlongSegment(current, px, py)
+  if (onCurrent.distanceSq <= toleranceSq) {
+    return {
+      segmentIndex: previous.segmentIndex,
+      fraction: Math.max(previous.fraction, onCurrent.fraction),
+    }
+  }
+
+  const nextIndex = previous.segmentIndex + 1
+  if (nextIndex < segments.length) {
+    const onNext = measureProgressAlongSegment(segments[nextIndex], px, py)
+    if (onNext.distanceSq <= toleranceSq) {
+      return { segmentIndex: nextIndex, fraction: onNext.fraction }
+    }
+  }
+
+  if (previous.fraction >= 0.999) {
+    const endDistSq = pointDistanceSq(px, py, current.x1, current.y1)
+    if (endDistSq <= ENDPOINT_TOLERANCE_MM ** 2 && nextIndex < segments.length) {
+      return { segmentIndex: nextIndex, fraction: 0 }
+    }
+  }
+
+  return previous
+}
+
 function drawGrid(ctx: CanvasRenderingContext2D, w: number, h: number, t: Transform, units: Units) {
   const mmPerPx = 1 / t.scale
   const displayPerPx = mmToDisplay(mmPerPx, units)
@@ -933,6 +972,8 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
   const webglCanvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const model = useGCodeStore(s => s.model)
+  const sourceText = useGCodeStore(s => s.sourceText)
+  const fetchSourceText = useGCodeStore(s => s.fetchSourceText)
   const fileName = useGCodeStore(s => s.fileName)
   const loadedPath = useGCodeStore(s => s.loadedPath)
   const loading = useGCodeStore(s => s.loading)
@@ -962,6 +1003,7 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
   const renderRef = useRef<() => void>(() => {})
   const needsFitRef = useRef(true)
   const progressRef = useRef<ToolpathProgress | null>(null)
+  const lineProgressRef = useRef<ToolpathProgress | null>(null)
   const prevIsRunningRef = useRef(false)
   const prevModelRef = useRef<GCodeModel | null>(null)
 
@@ -1432,8 +1474,14 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
   const isViewerStartBlocked = loading || isProcessing2D || pendingPath !== null
   const is3DToggleDisabled = pendingPath !== null || isProcessing2D || (!!model && !is3DReady)
   const [autoFollow, setAutoFollow] = useState(true)
+  const [showCodePanel, setShowCodePanel] = useState(false)
+  const [sourceTextLoading, setSourceTextLoading] = useState(false)
   const [coolantState, setCoolantState] = useState<'off' | 'mist' | 'flood'>('off')
   const [currentSourceLine, setCurrentSourceLine] = useState<number | null>(null)
+  const sourceTextIndex = useMemo(
+    () => (sourceText ? buildSourceLineIndex(sourceText) : null),
+    [sourceText],
+  )
 
   // Keep refs in sync so render() (called from non-React contexts) reads current values
   showRapidsRef.current = showRapids
@@ -1455,6 +1503,7 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
       : null
     markerGeometryRef.current = null
     progressRef.current = null
+    lineProgressRef.current = null
     if (model && model !== prevModelRef.current) {
       needsFitRef.current = true
       if (is3D && !storeGeometry3D) {
@@ -1781,29 +1830,58 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
   useEffect(() => {
     if (isRunning && modelRef.current) {
       const progressOverlayEnabled = modelRef.current.segments.length <= LARGE_PROGRESS_OVERLAY_SEGMENT_LIMIT
-
       const freshStart = !prevIsRunningRef.current || model !== prevModelRef.current
-      if (!progressOverlayEnabled) {
-        progressRef.current = null
-      } else if (freshStart) {
+
+      if (freshStart) {
         progressRef.current = { segmentIndex: 0, fraction: 0 }
+        lineProgressRef.current = { segmentIndex: 0, fraction: 0 }
       } else {
-        progressRef.current = findToolpathProgress(
+        lineProgressRef.current = findLineToolpathProgress(
           modelRef.current.segments,
           status.wpos.x,
           status.wpos.y,
-          progressRef.current,
+          lineProgressRef.current,
         )
+        if (progressOverlayEnabled) {
+          progressRef.current = findToolpathProgress(
+            modelRef.current.segments,
+            status.wpos.x,
+            status.wpos.y,
+            progressRef.current,
+          )
+        } else {
+          progressRef.current = null
+        }
       }
     } else {
       progressRef.current = null
+      lineProgressRef.current = null
     }
-    if (isRunning && modelRef.current) {
-      setCurrentSourceLine(resolveRunningSourceLine(
-        modelRef.current,
-        progressRef.current?.segmentIndex ?? null,
-        status.sdPercent,
-      ))
+
+    if (isRunning && (modelRef.current || sourceText)) {
+      const mdl = modelRef.current
+      const idx = mdl
+        ? {
+            sourceLineCount: mdl.sourceLineCount,
+            lineByteOffsets: mdl.lineByteOffsets,
+            sourceByteLength: mdl.sourceByteLength,
+            lineNumberToSourceLine: mdl.lineNumberToSourceLine,
+          }
+        : sourceTextIndex
+
+      const lineProgress = lineProgressRef.current
+      setCurrentSourceLine(resolveRunningSourceLine({
+        sourceLineCount: idx?.sourceLineCount ?? 0,
+        lineByteOffsets: idx?.lineByteOffsets,
+        sourceByteLength: idx?.sourceByteLength,
+        lineNumberToSourceLine: idx?.lineNumberToSourceLine,
+        segments: mdl?.segments,
+        segmentIndex: lineProgress?.segmentIndex ?? null,
+        segmentFraction: lineProgress?.fraction ?? 0,
+        executingLineNumber: status.lineNumber,
+        // SD percent is bytes read into the parser buffer — only use when no toolpath model.
+        sdPercent: mdl ? undefined : status.sdPercent,
+      }))
     } else {
       setCurrentSourceLine(null)
     }
@@ -1826,6 +1904,9 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
     status.wco.x,
     status.wco.y,
     status.sdPercent,
+    status.lineNumber,
+    sourceText,
+    sourceTextIndex,
     controllerSettings.maxTravelX,
     controllerSettings.maxTravelY,
     controllerSettings.homingDirInvert,
@@ -2015,6 +2096,15 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
 
   const loadFromText = useGCodeStore(s => s.loadFromText)
 
+  useEffect(() => {
+    if (!showCodePanel || sourceText || !loadedPath) return
+    let cancelled = false
+    setSourceTextLoading(true)
+    fetchSourceText()
+      .finally(() => { if (!cancelled) setSourceTextLoading(false) })
+    return () => { cancelled = true }
+  }, [showCodePanel, sourceText, loadedPath, fetchSourceText])
+
   function onDrop(e: React.DragEvent) {
     e.preventDefault()
     const file = e.dataTransfer.files?.[0]
@@ -2135,6 +2225,18 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
             </button>
           )}
           <button
+            className={`${btnCls} ${showCodePanel ? 'text-info bg-info/10' : 'text-text-dim bg-elevated hover:text-text-primary'} ${!fileName && !loadedPath ? 'opacity-50 cursor-not-allowed hover:text-text-dim hover:bg-elevated' : ''}`}
+            onClick={() => {
+              if (!fileName && !loadedPath) return
+              setShowCodePanel(v => !v)
+            }}
+            title="Show G-code source text"
+            disabled={!fileName && !loadedPath}
+          >
+            <FileText size={iconSize} />
+            <span>Code</span>
+          </button>
+          <button
             className={`${btnCls} text-text-muted hover:text-text-primary hover:bg-elevated`}
             onClick={() => fitToView()}
             title="Fit entire path to view"
@@ -2147,9 +2249,10 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
         </div>
       </div>
 
+      <div className={`flex flex-1 min-h-0 ${showCodePanel ? 'flex-col lg:flex-row' : ''}`}>
       <div
         ref={containerRef}
-        className="flex-1 min-h-0 relative cursor-grab active:cursor-grabbing"
+        className={`${showCodePanel ? 'flex-1 min-h-[180px] lg:min-h-0 lg:min-w-0' : 'flex-1 min-h-0'} relative cursor-grab active:cursor-grabbing`}
         style={{ touchAction: 'none' }}
         onDrop={onDrop}
         onDragOver={onDragOver}
@@ -2352,6 +2455,17 @@ export function GCodeViewer({ className, isTablet, showOverrides }: Props) {
             <text x="16" y="18" fontSize="10" fill={AXIS_Y_COLOR} fontFamily="ui-monospace,monospace" fontWeight="700">Y</text>
           </svg>
         )}
+      </div>
+
+      {showCodePanel && (
+        <GCodeTextPanel
+          text={sourceText}
+          loading={sourceTextLoading}
+          activeLine={currentSourceLine}
+          followActiveLine={isJobRunning || isJobHeld}
+          className={`${isTablet ? 'h-[38vh]' : 'h-[34vh]'} lg:h-auto lg:w-[min(420px,38%)] border-t lg:border-t-0 lg:border-l border-border shrink-0`}
+        />
+      )}
       </div>
 
       {/* Permanent bottom strip */}

--- a/src/lib/gcode.ts
+++ b/src/lib/gcode.ts
@@ -14,12 +14,17 @@ export interface Segment {
   i?: number; j?: number; k?: number
   /** true = clockwise arc (G2) */
   cw?: boolean
+  /** 1-based line number in the source file that created this segment */
+  sourceLine?: number
 }
 
 export interface GCodeModel {
   segments: Segment[]
   bounds: { minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number }
+  /** Number of toolpath segments (motion blocks) */
   totalLines: number
+  /** Total lines in the source file (including blanks and comments) */
+  sourceLineCount: number
 }
 
 /** Map segment index → approximate source-line fraction (0..1) */
@@ -56,8 +61,14 @@ export function parseGCode(text: string): GCodeModel {
     if (pz > bounds.maxZ) bounds.maxZ = pz
   }
 
+  function pushSegment(seg: Omit<Segment, 'sourceLine'>, sourceLine: number) {
+    segments.push({ ...seg, sourceLine })
+  }
+
   const lines = text.split('\n')
-  for (const raw of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const sourceLine = lineIndex + 1
+    const raw = lines[lineIndex]
     const line = raw.split(';')[0].split('(')[0].trim().toUpperCase()
     if (!line) continue
 
@@ -125,13 +136,13 @@ export function parseGCode(text: string): GCodeModel {
         z = (words.Z ?? z) + offZ
         expandBounds(x0, y0, z0)
         expandBounds(x, y, z)
-        segments.push({ x0, y0, z0, x1: x, y1: y, z1: z, moveType: 'rapid' })
+        pushSegment({ x0, y0, z0, x1: x, y1: y, z1: z, moveType: 'rapid' }, sourceLine)
       }
       const xi = x, yi = y, zi = z
       x = 0; y = 0; z = 0
       expandBounds(xi, yi, zi)
       expandBounds(x, y, z)
-      segments.push({ x0: xi, y0: yi, z0: zi, x1: x, y1: y, z1: z, moveType: 'rapid' })
+      pushSegment({ x0: xi, y0: yi, z0: zi, x1: x, y1: y, z1: z, moveType: 'rapid' }, sourceLine)
       continue
     }
 
@@ -209,13 +220,13 @@ export function parseGCode(text: string): GCodeModel {
               }
             }
           }
-          segments.push({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, i, j, k, cw, ...feedData })
+          pushSegment({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, i, j, k, cw, ...feedData }, sourceLine)
         } else {
           // Treat degenerate arc as a line
-          segments.push({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, ...feedData })
+          pushSegment({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, ...feedData }, sourceLine)
         }
       } else {
-        segments.push({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, ...feedData })
+        pushSegment({ x0, y0, z0, x1: x, y1: y, z1: z, moveType, ...feedData }, sourceLine)
       }
     }
   }
@@ -226,5 +237,25 @@ export function parseGCode(text: string): GCodeModel {
     bounds.maxX = bounds.maxY = bounds.maxZ = 1
   }
 
-  return { segments, bounds, totalLines: segments.length }
+  return { segments, bounds, totalLines: segments.length, sourceLineCount: lines.length }
+}
+
+/** Resolve the current source line while a job is running. */
+export function resolveRunningSourceLine(
+  model: GCodeModel | null,
+  segmentIndex: number | null,
+  sdPercent: number | undefined,
+): number | null {
+  if (!model) return null
+  if (segmentIndex != null) {
+    const seg = model.segments[segmentIndex]
+    if (seg?.sourceLine != null) return seg.sourceLine
+  }
+  if (sdPercent != null && model.sourceLineCount > 0) {
+    return Math.max(1, Math.min(
+      model.sourceLineCount,
+      Math.round((sdPercent / 100) * model.sourceLineCount),
+    ))
+  }
+  return null
 }

--- a/src/lib/gcode.ts
+++ b/src/lib/gcode.ts
@@ -25,6 +25,12 @@ export interface GCodeModel {
   totalLines: number
   /** Total lines in the source file (including blanks and comments) */
   sourceLineCount: number
+  /** Byte offset of each 1-based source line start (for SD progress mapping) */
+  lineByteOffsets: number[]
+  /** Total byte length of the source text (including newlines) */
+  sourceByteLength: number
+  /** Maps G-code N-word values to 1-based source line numbers */
+  lineNumberToSourceLine: Record<number, number>
 }
 
 /** Map segment index → approximate source-line fraction (0..1) */
@@ -32,7 +38,30 @@ export function segmentProgress(idx: number, total: number): number {
   return total > 0 ? idx / total : 0
 }
 
+export function buildSourceLineIndex(text: string) {
+  const lines = text.split('\n')
+  const lineByteOffsets: number[] = []
+  const lineNumberToSourceLine: Record<number, number> = {}
+  let sourceByteLength = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    lineByteOffsets.push(sourceByteLength)
+    sourceByteLength += lines[i].length + 1
+    const stripped = lines[i].split(';')[0].split('(')[0].trim().toUpperCase()
+    const nMatch = stripped.match(/(?:^|\s)N(\d+)\b/)
+    if (nMatch) lineNumberToSourceLine[parseInt(nMatch[1], 10)] = i + 1
+  }
+
+  return {
+    sourceLineCount: lines.length,
+    lineByteOffsets,
+    sourceByteLength,
+    lineNumberToSourceLine,
+  }
+}
+
 export function parseGCode(text: string): GCodeModel {
+  const { sourceLineCount, lineByteOffsets, sourceByteLength, lineNumberToSourceLine } = buildSourceLineIndex(text)
   const segments: Segment[] = []
   let x = 0, y = 0, z = 0
   let offX = 0, offY = 0, offZ = 0        // G92 coordinate offsets
@@ -69,6 +98,7 @@ export function parseGCode(text: string): GCodeModel {
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const sourceLine = lineIndex + 1
     const raw = lines[lineIndex]
+
     const line = raw.split(';')[0].split('(')[0].trim().toUpperCase()
     if (!line) continue
 
@@ -237,25 +267,119 @@ export function parseGCode(text: string): GCodeModel {
     bounds.maxX = bounds.maxY = bounds.maxZ = 1
   }
 
-  return { segments, bounds, totalLines: segments.length, sourceLineCount: lines.length }
+  return {
+    segments,
+    bounds,
+    totalLines: segments.length,
+    sourceLineCount,
+    lineByteOffsets,
+    sourceByteLength,
+    lineNumberToSourceLine,
+  }
+}
+
+function sourceLineAtByteOffset(lineByteOffsets: number[], sourceByteLength: number, bytePos: number): number {
+  const clamped = Math.max(0, Math.min(sourceByteLength, bytePos))
+  let lo = 0
+  let hi = lineByteOffsets.length - 1
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi + 1) / 2)
+    if (lineByteOffsets[mid] <= clamped) lo = mid
+    else hi = mid - 1
+  }
+  return lo + 1
+}
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, value))
+}
+
+function segmentPathLength(seg: Segment): number {
+  return Math.hypot(seg.x1 - seg.x0, seg.y1 - seg.y0, seg.z1 - seg.z0)
+}
+
+/** Interpolate source line from fractional progress along the toolpath. */
+function resolveSourceLineFromSegmentProgress(
+  segments: Segment[],
+  segmentIndex: number,
+  fraction: number,
+): number | null {
+  if (!segments.length) return null
+
+  const lengths = segments.map(segmentPathLength)
+  const total = lengths.reduce((sum, len) => sum + len, 0)
+  if (total <= 0) return segments[0].sourceLine ?? null
+
+  const idx = Math.max(0, Math.min(segments.length - 1, segmentIndex))
+  let target = 0
+  for (let i = 0; i < idx; i++) target += lengths[i]
+  target += lengths[idx] * clamp01(fraction)
+
+  let dist = 0
+  for (let i = 0; i < segments.length; i++) {
+    const len = lengths[i]
+    const nextDist = dist + len
+    if (nextDist >= target - 1e-9 || i === segments.length - 1) {
+      const localT = len > 0 ? clamp01((target - dist) / len) : 0
+      const line0 = segments[i].sourceLine ?? 1
+      const line1 = segments[i + 1]?.sourceLine ?? line0
+      if (line0 === line1) return line0
+      return Math.max(1, Math.round(line0 + localT * (line1 - line0)))
+    }
+    dist = nextDist
+  }
+
+  return segments[segments.length - 1].sourceLine ?? null
+}
+
+export interface RunningLineContext {
+  sourceLineCount: number
+  lineByteOffsets?: number[]
+  sourceByteLength?: number
+  lineNumberToSourceLine?: Record<number, number>
+  segments?: Segment[]
+  segmentIndex?: number | null
+  /** 0–1 progress through the current segment */
+  segmentFraction?: number
+  /** FluidNC |Ln:N| from the planner block currently executing */
+  executingLineNumber?: number
+  /** SD file read progress 0–100 (bytes read, may be ahead of execution) */
+  sdPercent?: number
 }
 
 /** Resolve the current source line while a job is running. */
-export function resolveRunningSourceLine(
-  model: GCodeModel | null,
-  segmentIndex: number | null,
-  sdPercent: number | undefined,
-): number | null {
-  if (!model) return null
-  if (segmentIndex != null) {
-    const seg = model.segments[segmentIndex]
-    if (seg?.sourceLine != null) return seg.sourceLine
+export function resolveRunningSourceLine(ctx: RunningLineContext): number | null {
+  const {
+    sourceLineCount,
+    lineByteOffsets,
+    sourceByteLength,
+    lineNumberToSourceLine,
+    segments,
+    segmentIndex,
+    segmentFraction = 0,
+    executingLineNumber,
+    sdPercent,
+  } = ctx
+
+  if (sourceLineCount <= 0) return null
+
+  // Best: tool position along parsed path — interpolates between source lines.
+  if (segmentIndex != null && segments?.length) {
+    const fromPath = resolveSourceLineFromSegmentProgress(segments, segmentIndex, segmentFraction)
+    if (fromPath != null) return fromPath
   }
-  if (sdPercent != null && model.sourceLineCount > 0) {
-    return Math.max(1, Math.min(
-      model.sourceLineCount,
-      Math.round((sdPercent / 100) * model.sourceLineCount),
-    ))
+
+  // FluidNC Ln: updates per planner block (often coarse N-word steps).
+  if (executingLineNumber != null && executingLineNumber > 0) {
+    const mapped = lineNumberToSourceLine?.[executingLineNumber]
+    if (mapped != null) return mapped
   }
+
+  // Last resort: SD percent is bytes read from file (often ahead of execution).
+  if (sdPercent != null && lineByteOffsets && sourceByteLength && sourceByteLength > 0) {
+    const bytePos = (sdPercent / 100) * sourceByteLength
+    return sourceLineAtByteOffset(lineByteOffsets, sourceByteLength, bytePos)
+  }
+
   return null
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -17,6 +17,7 @@ export function parseStatusReport(raw: string): Partial<MachineStatus> | null {
   status.spindle = 0
 
   let hasSd = false
+  let hasLn = false
   for (let i = 1; i < parts.length; i++) {
     const p = parts[i]
     if (p.startsWith('WPos:')) {
@@ -25,6 +26,10 @@ export function parseStatusReport(raw: string): Partial<MachineStatus> | null {
       status.mpos = parsePos(p.slice(5))
     } else if (p.startsWith('WCO:')) {
       status.wco = parsePos(p.slice(4))
+    } else if (p.startsWith('Ln:')) {
+      hasLn = true
+      const ln = parseInt(p.slice(3), 10)
+      status.lineNumber = Number.isFinite(ln) && ln > 0 ? ln : undefined
     } else if (p.startsWith('FS:')) {
       const [f, s] = p.slice(3).split(',').map(Number)
       status.feed = f ?? 0
@@ -47,6 +52,9 @@ export function parseStatusReport(raw: string): Partial<MachineStatus> | null {
   if (!hasSd) {
     status.sdPercent = undefined
     status.sdFilename = undefined
+  }
+  if (!hasLn) {
+    status.lineNumber = undefined
   }
 
   return status

--- a/src/store/gcode.ts
+++ b/src/store/gcode.ts
@@ -22,6 +22,8 @@ interface GCodeStore {
 
   // Built data (shared across all GCodeViewer instances — one parse, one build)
   model: GCodeModel | null
+  /** Raw G-code source text for the loaded file */
+  sourceText: string | null
   paths2D: Built2DPaths | null
   geometry3D: Geometry3D | null
 
@@ -41,6 +43,7 @@ interface GCodeStore {
   // Actions
   loadFile: (path: string) => Promise<void>
   loadFromText: (text: string, name: string) => Promise<void>
+  fetchSourceText: () => Promise<string | null>
   cancelAndStartJob: (path: string) => void
   setShowRapids: (v: boolean) => void
   clear: () => void
@@ -74,6 +77,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
   loadedPath: null,
   fileName: null,
   model: null,
+  sourceText: null,
   paths2D: null,
   geometry3D: null,
   showRapids: true,
@@ -105,6 +109,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
       is3DReady: false,
       geometry3D: null,
       paths2D: null,
+      sourceText: null,
     })
 
     try {
@@ -171,6 +176,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
       const fileName = path.split('/').pop() ?? path
       set({
         model: parsed,
+        sourceText: text,
         paths2D: built2DPaths,
         fileName,
         loadedPath: path,
@@ -239,6 +245,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
       is3DReady: false,
       geometry3D: null,
       paths2D: null,
+      sourceText: null,
     })
 
     try {
@@ -260,6 +267,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
 
       set({
         model: parsed,
+        sourceText: text,
         paths2D: built2DPaths,
         fileName: name,
         loadedPath: null,
@@ -303,6 +311,23 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
     }
   },
 
+  fetchSourceText: async () => {
+    const { sourceText, loadedPath } = get()
+    if (sourceText) return sourceText
+    if (!loadedPath) return null
+
+    try {
+      const res = await fetch(`${getBase()}${loadedPath}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const text = await res.text()
+      if (get().loadedPath === loadedPath) set({ sourceText: text })
+      return text
+    } catch (e) {
+      console.error('Failed to fetch G-code text:', e)
+      return null
+    }
+  },
+
   cancelAndStartJob: (path: string) => {
     // Stop any in-flight download immediately. The ESP32 must not be serving a
     abortInFlight()
@@ -318,6 +343,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
       fileName: path.split('/').pop() ?? path,
       // Drop any partial built data — they're stale now.
       model: null,
+      sourceText: null,
       paths2D: null,
       geometry3D: null,
       is3DReady: false,
@@ -364,6 +390,7 @@ export const useGCodeStore = create<GCodeStore>((set, get) => ({
       loadedPath: null,
       fileName: null,
       model: null,
+      sourceText: null,
       paths2D: null,
       geometry3D: null,
       loading: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface MachineStatus {
   pinState: string
   sdFilename?: string
   sdPercent?: number
+  /** FluidNC |Ln:N| — N word on the planner block currently executing */
+  lineNumber?: number
   gcodeModes?: GCodeModes
 }
 


### PR DESCRIPTION
## Summary
- Track 1-based source line numbers on each parsed G-code segment
- Display `Line X / Y` in the viewer progress strip while a job is running or held
- Add a **Code** toggle in the G-code viewer toolbar with a scrollable source text panel
- Highlight and auto-scroll the current line in the text panel during Run/Hold
- Resolve the running line from toolpath position (with segment fraction interpolation) instead of SD byte-read progress, which reflects parser buffer position ahead of execution
- Parse FluidNC `|Ln:N|` from status reports when `use_line_numbers` is enabled and map N-words to source lines
- Store loaded G-code source text in the G-code store for the text panel

## Test plan
- [ ] Load a G-code file in the viewer and confirm **Code** shows the full source with line numbers
- [ ] Start a job from SD and confirm `Line X / Y` appears above the progress bar during Run/Hold
- [ ] With **Code** open, confirm the highlighted line tracks the job and auto-scrolls
- [ ] Verify line numbers advance smoothly during cuts (not jumping in large SD-percent blocks)
- [ ] Confirm the display clears when the job stops or completes
- [ ] Test with a file that has comments/blank lines to verify line count includes full source
- [ ] Optional: enable `use_line_numbers: true` in FluidNC and N-words in G-code for `Ln:` reporting