### PR TITLE
Add FluidNC WASM demo bridge support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,6 +337,74 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
@@ -349,6 +417,312 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -509,6 +883,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
@@ -521,6 +923,353 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@sveltejs/acorn-typescript": {
@@ -3927,21 +4676,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,28 +144,29 @@ export function App() {
       ? await getDeviceInfoFast()
       : await getDeviceInfo()
     const info = parseESP800(raw)
-    const wsComm = info['webcommunication']?.trim() ?? ''
-    const parts  = wsComm.split(':')
-    const asyncMode = parts[0]?.trim() === 'Async'
-    const wsPort = parts[1]?.trim() ?? '80'
-    const wsIp   = parts[2]?.trim() ?? httpHost.split(':')[0]
+    const asyncMode = info['WebCommunication']?.trim() === 'Asynchronous'
+    const wsPort = info['WebSocketPort']?.trim() || '80'
+    const wsIp   = info['WebSocketIP']?.trim() || httpHost.split(':')[0]
     const wsHost = asyncMode
       ? `${httpHost}/ws`
       : wsPort === '80' ? wsIp : `${wsIp}:${wsPort}`
     cachedWsHost.current = wsHost
     cachedHostFailures.current = 0
     // Only refresh ESP info on a fresh probe.
-    const axes = parseInt(info['axis'] ?? '3', 10)
+    const axes = (info['Axisletters'] ?? '').length
     setEspInfo({
-      version:        info['FW version']?.trim()     ?? '',
-      hostname:       info['hostname']?.trim()        ?? httpHost,
-      authentication: info['authentication']?.trim()  === 'yes',
+      version:        info['FWVersion']?.trim()       ?? '',
+      hostname:       info['HostName']?.trim()         ?? httpHost,
+      authentication: info['Authentication']?.trim()   === 'Enabled',
       asyncMode,
       wsPort:         parseInt(wsPort, 10),
       wsIp,
-      axes:           isNaN(axes) ? 3 : axes,
-      primarySd:      info['primary sd']?.trim()     ?? '/sd/',
-      secondarySd:    info['secondary sd']?.trim()   ?? '/ext/',
+      axes:           axes || 3,
+      // No JSON equivalent for these (the legacy plain-text response's
+      // "primary sd"/"secondary sd" fields) -- same defaults the old
+      // parse already fell back to whenever they were absent/unparseable.
+      primarySd:      '/sd/',
+      secondarySd:    '/ext/',
     })
     return { wsHost, info }
   }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -70,7 +70,7 @@ export const sendSilent = (cmd: string) =>
   get('/command_silent', { plain: cmd })
 
 export const getDeviceInfoFast = () =>
-  get('/command', { plain: '[ESP800]' }, 4000)
+  get('/command', { plain: '[ESP800]json=yes' }, 4000)
 
 export function listFiles(path: string, fs: 'sd' | 'local' = 'sd'): Promise<FileListResult> {
   return serialize(async () => {
@@ -214,7 +214,7 @@ export async function saveFileContent(
   await uploadFile(path, file, fs)
 }
 
-export const getDeviceInfo = () => sendCommand('[ESP800]')
+export const getDeviceInfo = () => sendCommand('[ESP800]json=yes')
 
 export function uploadFirmware(
   file: File,

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -63,14 +63,27 @@ function parsePos(str: string): Position {
   return { x: x ?? 0, y: y ?? 0, z: z ?? 0, a, b, c }
 }
 
+// [ESP800]json=yes wraps the same fields the legacy "FW version:... #
+// FW target:... # ..." plain-text response carried in {cmd,status,data}
+// instead -- see WifiConfig.cpp's showFwInfoJSON()/wasm/FwInfo.cpp. Field
+// names change shape too (e.g. "webcommunication:Sync:81:127.0.0.1"
+// becomes separate WebCommunication/WebSocketPort/WebSocketIP fields, and
+// "authentication:yes" becomes "Authentication":"Enabled") -- see
+// App.tsx's resolveWsHost(), the only real consumer, for how those are
+// read now.
 export function parseESP800(raw: string): Record<string, string> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  const data = (parsed as { data?: Record<string, unknown> })?.data
+  if (!data) return {}
   const result: Record<string, string> = {}
-  raw.split('#').forEach(part => {
-    const idx = part.indexOf(':')
-    if (idx > -1) {
-      result[part.slice(0, idx).trim()] = part.slice(idx + 1).trim()
-    }
-  })
+  for (const [key, value] of Object.entries(data)) {
+    result[key] = String(value)
+  }
   return result
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,11 +5,18 @@ import { App } from './App'
 import './store/terminal'
 import './lib/jogWatchdog'
 import { disconnect as disconnectWs } from './lib/ws'
+import { installWasmBridgeIfActive } from './wasmBridge'
 
 if (import.meta.env.VITE_DEMO_MODE) {
   const { installDemoMode } = await import('./demo')
   installDemoMode()
 }
+
+// Not gated by import.meta.env, unlike installDemoMode() above -- this must
+// survive in every build mode (including the real `build:esp32` artifact),
+// since it's how a stock build detects it's running inside the FluidNC WASM
+// demo at runtime. See wasmBridge/index.ts.
+installWasmBridgeIfActive()
 
 window.addEventListener('pagehide', () => { disconnectWs() })
 

--- a/src/wasmBridge/WasmBridgeWebSocket.ts
+++ b/src/wasmBridge/WasmBridgeWebSocket.ts
@@ -1,0 +1,102 @@
+// A WebSocket-shaped class backed by the WASM demo's postMessage bridge
+// instead of a real network socket -- installed as `window.WebSocket` (see
+// index.ts) so src/lib/ws.ts works completely unmodified, the same way it
+// talks to a real FluidNC WebSocket. Modeled directly on src/demo/
+// wsSimulator.ts's FakeWebSocket (same public surface, since that's what
+// ws.ts's `new WebSocket(url, 'arduino')` call needs), but instead of
+// simulating a machine in JS, it relays to a real compiled FluidNC instance
+// via shimTransport's postMessage channel.
+//
+// Known limitation: on real hardware, /command (src/lib/http.ts) and this
+// WebSocket are genuinely independent connections, each answered by its own
+// Channel object, so their response streams never cross. Here they both
+// share the one physical ShimChannel (see commandBridge.ts's module
+// comment), so an HTTP-shaped /command call that races with WebSocket
+// traffic could in principle have its response line misattributed. In
+// practice /command calls are rare (mostly startup queries), so this is
+// left as a known gap rather than adding a second wasm-side channel.
+import { sendToShim, addShimLineListener } from './shimTransport'
+
+export class WasmBridgeWebSocket extends EventTarget {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState: number = 0
+  binaryType: BinaryType = 'arraybuffer'
+  readonly url: string
+  readonly protocol: string
+  readonly bufferedAmount = 0
+  readonly extensions = ''
+
+  onopen: ((e: Event) => void) | null = null
+  onclose: ((e: CloseEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+
+  private unsubscribe: (() => void) | null = null
+
+  constructor(url: string, protocols?: string | string[]) {
+    super()
+    this.url = url
+    this.protocol = Array.isArray(protocols) ? (protocols[0] ?? '') : (protocols ?? '')
+    // Deferred rather than synchronous so callers that set onopen/onmessage
+    // right after `new WebSocket(...)` (as ws.ts does) don't miss the open
+    // event -- matches a real WebSocket's inherently async connect.
+    setTimeout(() => this._open(), 0)
+  }
+
+  private _open() {
+    this.readyState = 1
+    // isJson is irrelevant here: whether a line came from a [JSON:...]
+    // reassembly or not, ws.ts wants the same thing real hardware's
+    // WSChannel would have sent it -- plain unwrapped text.
+    this.unsubscribe = addShimLineListener((line) => {
+      const ev = new MessageEvent('message', { data: `${line}\n` })
+      this.onmessage?.(ev)
+      this.dispatchEvent(ev)
+    })
+    const ev = new Event('open')
+    this.onopen?.(ev)
+    this.dispatchEvent(ev)
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+    if (this.readyState !== 1) return
+
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      const buf =
+        data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : new Uint8Array((data as ArrayBufferView).buffer, (data as ArrayBufferView).byteOffset, (data as ArrayBufferView).byteLength)
+      // Realtime bytes ('?', ctrl-X, ...) -- ws.ts sends these as a single
+      // byte, same as it would write to a real socket. sendToShim() takes a
+      // string (emscripten's cwrap marshals it as UTF-8), and every
+      // realtime byte FluidNC defines is single-byte-UTF8-safe.
+      sendToShim(String.fromCharCode(...buf))
+      return
+    }
+
+    if (typeof data === 'string') {
+      sendToShim(data)
+    }
+  }
+
+  close(code?: number, reason?: string) {
+    if (this.readyState === 3) return
+    this.readyState = 3
+    if (this.unsubscribe) {
+      this.unsubscribe()
+      this.unsubscribe = null
+    }
+    const ev = new CloseEvent('close', { wasClean: true, code: code ?? 1000, reason: reason ?? '' })
+    this.onclose?.(ev)
+    this.dispatchEvent(ev)
+  }
+}

--- a/src/wasmBridge/WasmBridgeWebSocket.ts
+++ b/src/wasmBridge/WasmBridgeWebSocket.ts
@@ -10,11 +10,16 @@
 // Known limitation: on real hardware, /command (src/lib/http.ts) and this
 // WebSocket are genuinely independent connections, each answered by its own
 // Channel object, so their response streams never cross. Here they both
-// share the one physical ShimChannel (see commandBridge.ts's module
-// comment), so an HTTP-shaped /command call that races with WebSocket
-// traffic could in principle have its response line misattributed. In
-// practice /command calls are rare (mostly startup queries), so this is
-// left as a known gap rather than adding a second wasm-side channel.
+// share the one physical ShimChannel. demo/index.html's 'fluidnc-shim-
+// command' RPC (see commandBridge.ts, shimTransport.ts's sendShimCommand())
+// now queues /command calls against each other centrally, so two of those
+// can no longer misattribute each other's response lines -- but an
+// HTTP-shaped /command call can still in principle race a raw G-code send
+// made directly through this WebSocket (send() below posts straight to the
+// shim, bypassing that queue), and have its ok/error line misattributed to
+// whichever one asked first. In practice /command calls are rare (mostly
+// startup queries), so that narrower remaining gap is left as-is rather
+// than adding a second wasm-side channel.
 import { sendToShim, addShimLineListener } from './shimTransport'
 
 export class WasmBridgeWebSocket extends EventTarget {

--- a/src/wasmBridge/WasmBridgeWebSocket.ts
+++ b/src/wasmBridge/WasmBridgeWebSocket.ts
@@ -7,19 +7,21 @@
 // simulating a machine in JS, it relays to a real compiled FluidNC instance
 // via shimTransport's postMessage channel.
 //
-// Known limitation: on real hardware, /command (src/lib/http.ts) and this
-// WebSocket are genuinely independent connections, each answered by its own
-// Channel object, so their response streams never cross. Here they both
-// share the one physical ShimChannel. demo/index.html's 'fluidnc-shim-
-// command' RPC (see commandBridge.ts, shimTransport.ts's sendShimCommand())
-// now queues /command calls against each other centrally, so two of those
-// can no longer misattribute each other's response lines -- but an
-// HTTP-shaped /command call can still in principle race a raw G-code send
-// made directly through this WebSocket (send() below posts straight to the
-// shim, bypassing that queue), and have its ok/error line misattributed to
-// whichever one asked first. In practice /command calls are rare (mostly
-// startup queries), so that narrower remaining gap is left as-is rather
-// than adding a second wasm-side channel.
+// On real hardware, /command (src/lib/http.ts) and this WebSocket are
+// genuinely independent connections, each answered by its own Channel
+// object, so their response streams never cross. Here they both share
+// the one physical ShimChannel, so demo/index.html serializes every send
+// -- both /command's 'fluidnc-shim-command' RPC and this class's own
+// raw sends below -- through one central queue (see its deliverShimLine()
+// /maybeStartNextShimSend()), so only one thing is ever unacknowledged on
+// the shim at a time and nothing can misattribute another's ok/error
+// line. (An earlier version only queued /command calls against each
+// other, on the theory that a raw send here couldn't be affected either
+// way -- that turned out to be wrong: FluidNC's output for one call can
+// arrive split across more than one output event, leaving a gap where a
+// second queued /command could start and steal this class's own ok/error
+// line. Send() below still posts straight to the shim -- the ordering
+// guarantee now lives entirely in demo/index.html's queue instead.)
 import { sendToShim, addShimLineListener } from './shimTransport'
 
 export class WasmBridgeWebSocket extends EventTarget {

--- a/src/wasmBridge/commandBridge.ts
+++ b/src/wasmBridge/commandBridge.ts
@@ -4,13 +4,15 @@
 // WebUIServer.cpp). That handler isn't compiled into the wasm build at all
 // (WebUI/ is excluded -- see platformio.ini's [env:wasm] build_src_filter),
 // so every command here is forwarded through the same shim channel
-// WasmBridgeWebSocket reads from, using the grbl-line ok/error protocol
-// directly (see shimTransport.ts). [ESP800] is the one exception: FluidNC's
-// real handler for it lives in WebUI/WifiConfig.cpp, also excluded, and its
-// only real purpose here is the capability-discovery handshake (App.tsx's
-// parseESP800), not live device state -- so it's spoofed locally, matching
-// WebUI-mm's commandTransport.ts.
-import { sendToShim, addShimLineListener } from './shimTransport'
+// WasmBridgeWebSocket reads from, using shimTransport's sendShimCommand()
+// (demo/index.html collects the response and queues concurrent sends
+// centrally, so this doesn't need to serialize them itself anymore).
+// [ESP800] is the one exception: FluidNC's real handler for it lives in
+// WebUI/WifiConfig.cpp, also excluded, and its only real purpose here is
+// the capability-discovery handshake (App.tsx's parseESP800), not live
+// device state -- so it's spoofed locally, matching WebUI-mm's
+// commandTransport.ts.
+import { sendShimCommand } from './shimTransport'
 
 const FAKE_ESP800_RESPONSE = [
   'FW version:FluidNC v4.0.3 (wasm-demo)',
@@ -24,43 +26,9 @@ const FAKE_ESP800_RESPONSE = [
   'axis:3',
 ].join('#')
 
-// Only one of these may be in flight at a time -- see the module comment in
-// httpBridge.ts for why (this shares one physical ShimChannel with
-// WasmBridgeWebSocket's own live command stream, unlike real hardware where
-// /command and the WebSocket are genuinely independent connections/channels
-// each with their own response stream).
-let chain: Promise<unknown> = Promise.resolve()
-
 export function sendBridgeCommand(cmd: string): Promise<string> {
   if (cmd === '[ESP800]') {
     return Promise.resolve(FAKE_ESP800_RESPONSE)
   }
-
-  const next = chain.then(() => sendOnce(cmd), () => sendOnce(cmd))
-  chain = next.catch(() => {})
-  return next
-}
-
-function sendOnce(cmd: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const responseLines: string[] = []
-    let jsonText = ''
-    const unsubscribe = addShimLineListener((line, isJson) => {
-      if (!isJson && (line.startsWith('ok') || line.startsWith('error'))) {
-        unsubscribe()
-        if (line.startsWith('ok')) {
-          resolve(jsonText || responseLines.join('\n'))
-        } else {
-          reject(new Error(line))
-        }
-        return
-      }
-      if (isJson) {
-        jsonText += line
-      } else {
-        responseLines.push(line)
-      }
-    })
-    sendToShim(`${cmd}\n`)
-  })
+  return sendShimCommand(cmd)
 }

--- a/src/wasmBridge/commandBridge.ts
+++ b/src/wasmBridge/commandBridge.ts
@@ -7,28 +7,12 @@
 // WasmBridgeWebSocket reads from, using shimTransport's sendShimCommand()
 // (demo/index.html collects the response and queues concurrent sends
 // centrally, so this doesn't need to serialize them itself anymore).
-// [ESP800] is the one exception: FluidNC's real handler for it lives in
-// WebUI/WifiConfig.cpp, also excluded, and its only real purpose here is
-// the capability-discovery handshake (App.tsx's parseESP800), not live
-// device state -- so it's spoofed locally, matching WebUI-mm's
-// commandTransport.ts.
+// [ESP800] used to be spoofed locally here (its real handler lives in
+// WebUI/WifiConfig.cpp, also excluded, and needs WiFi/WebUI_Server APIs
+// that don't exist in this build) -- wasm/FwInfo.cpp now provides a real,
+// wasm-specific handler instead, so it's just another command.
 import { sendShimCommand } from './shimTransport'
 
-const FAKE_ESP800_RESPONSE = [
-  'FW version:FluidNC v4.0.3 (wasm-demo)',
-  'FW target:grbl-embedded',
-  'FW HW:Direct SD',
-  'primary sd:/sd/',
-  'secondary sd:none',
-  'authentication:no',
-  'webcommunication:Sync:81:127.0.0.1',
-  'hostname:fluidnc-wasm-demo',
-  'axis:3',
-].join('#')
-
 export function sendBridgeCommand(cmd: string): Promise<string> {
-  if (cmd === '[ESP800]') {
-    return Promise.resolve(FAKE_ESP800_RESPONSE)
-  }
   return sendShimCommand(cmd)
 }

--- a/src/wasmBridge/commandBridge.ts
+++ b/src/wasmBridge/commandBridge.ts
@@ -1,0 +1,66 @@
+// Request/response command sends for the wasm bridge's HTTP-shaped surface
+// (src/lib/http.ts's sendCommand/sendSilent/getDeviceInfo(Fast), which real
+// hardware answers over its /command endpoint -- see WebCommands.cpp /
+// WebUIServer.cpp). That handler isn't compiled into the wasm build at all
+// (WebUI/ is excluded -- see platformio.ini's [env:wasm] build_src_filter),
+// so every command here is forwarded through the same shim channel
+// WasmBridgeWebSocket reads from, using the grbl-line ok/error protocol
+// directly (see shimTransport.ts). [ESP800] is the one exception: FluidNC's
+// real handler for it lives in WebUI/WifiConfig.cpp, also excluded, and its
+// only real purpose here is the capability-discovery handshake (App.tsx's
+// parseESP800), not live device state -- so it's spoofed locally, matching
+// WebUI-mm's commandTransport.ts.
+import { sendToShim, addShimLineListener } from './shimTransport'
+
+const FAKE_ESP800_RESPONSE = [
+  'FW version:FluidNC v4.0.3 (wasm-demo)',
+  'FW target:grbl-embedded',
+  'FW HW:Direct SD',
+  'primary sd:/sd/',
+  'secondary sd:none',
+  'authentication:no',
+  'webcommunication:Sync:81:127.0.0.1',
+  'hostname:fluidnc-wasm-demo',
+  'axis:3',
+].join('#')
+
+// Only one of these may be in flight at a time -- see the module comment in
+// httpBridge.ts for why (this shares one physical ShimChannel with
+// WasmBridgeWebSocket's own live command stream, unlike real hardware where
+// /command and the WebSocket are genuinely independent connections/channels
+// each with their own response stream).
+let chain: Promise<unknown> = Promise.resolve()
+
+export function sendBridgeCommand(cmd: string): Promise<string> {
+  if (cmd === '[ESP800]') {
+    return Promise.resolve(FAKE_ESP800_RESPONSE)
+  }
+
+  const next = chain.then(() => sendOnce(cmd), () => sendOnce(cmd))
+  chain = next.catch(() => {})
+  return next
+}
+
+function sendOnce(cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const responseLines: string[] = []
+    let jsonText = ''
+    const unsubscribe = addShimLineListener((line, isJson) => {
+      if (!isJson && (line.startsWith('ok') || line.startsWith('error'))) {
+        unsubscribe()
+        if (line.startsWith('ok')) {
+          resolve(jsonText || responseLines.join('\n'))
+        } else {
+          reject(new Error(line))
+        }
+        return
+      }
+      if (isJson) {
+        jsonText += line
+      } else {
+        responseLines.push(line)
+      }
+    })
+    sendToShim(`${cmd}\n`)
+  })
+}

--- a/src/wasmBridge/httpBridge.ts
+++ b/src/wasmBridge/httpBridge.ts
@@ -1,0 +1,251 @@
+// fetch()/XMLHttpRequest interception for the wasm bridge, matching
+// src/lib/http.ts's real endpoints (/command, /command_silent, /upload,
+// /files, and direct /sd, /localfs, /ext downloads). Modeled directly on
+// src/demo/httpSimulator.ts (same URL matching), but backs file operations
+// with the real wasm filesystem via shimTransport's fsRequest() instead of
+// an in-memory JS simulation, and commands via commandBridge.ts instead of
+// canned responses.
+import { fsRequest } from './shimTransport'
+import { sendBridgeCommand } from './commandBridge'
+
+type Root = 'native_sd' | 'native_localfs'
+
+function rootForPath(p: string): Root {
+  return p === '/upload' ? 'native_sd' : 'native_localfs'
+}
+
+function joinPath(dir: string, name: string): string {
+  return (dir.endsWith('/') ? dir : `${dir}/`) + name
+}
+
+function ok(body: string, type = 'text/plain'): Response {
+  return new Response(body, { status: 200, headers: { 'Content-Type': type } })
+}
+
+// Manual parsing instead of `new URL(href, location.href)`: resolving a
+// relative reference against a blob: base throws ("Failed to construct
+// 'URL': Invalid URL") -- the same relative-resolution quirk that broke
+// Router.tsx's `location.href = ...` navigation elsewhere in this project,
+// now also hitting URL construction. It's compounded by a real FigUI bug:
+// src/App.tsx's attemptConnect() calls `setBase(\`http://${window.location
+// .host}\`)`, and window.location.host is empty inside this blob: iframe,
+// so requests end up as "http:///command?..." -- which the URL parser
+// reads as host="command", path="/", not what was intended. Since every
+// request we care about targets one of a small set of known endpoints,
+// recovering the real path+query by finding that endpoint name in the raw
+// string sidesteps both problems: it needs no base at all, and it isn't
+// fooled by the mis-parsed-host case either.
+const KNOWN_PATH_RE = /\/(command_silent|command|upload|files|localfs\/|sd(?:\/|(?=\?)|$))/
+
+function extractRequestUrl(href: string): { pathname: string; searchParams: URLSearchParams } | null {
+  const m = KNOWN_PATH_RE.exec(href)
+  if (!m) return null
+  const rest = href.slice(m.index)
+  const q = rest.indexOf('?')
+  const pathname = q >= 0 ? rest.slice(0, q) : rest
+  const searchParams = new URLSearchParams(q >= 0 ? rest.slice(q + 1) : '')
+  return { pathname, searchParams }
+}
+
+function errorResponse(message: string, status = 500): Response {
+  return new Response(message, { status })
+}
+
+// fluidnc_fs_list() (see wasm/wasm_fs_bridge.cpp) emits {"name","size"
+// (JSON number, -1 for dirs),"datetime"}; FigUI's http.ts::listFiles()
+// expects size as a *string*, checking `f.size === '-1'` for the directory
+// sentinel -- matching real FluidNC's FileCommands.cpp wire convention.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function reshapeListing(raw: any, path: string): unknown {
+  const files = (raw.files ?? []).map((f: { name: string; size: number; datetime?: string }) => ({
+    name: f.name,
+    shortname: f.name,
+    size: f.size < 0 ? '-1' : String(f.size),
+    isDir: f.size < 0,
+    datetime: f.datetime ?? '',
+  }))
+  return {
+    files,
+    path: raw.path ?? path,
+    total: raw.total,
+    used: raw.used,
+    occupation: raw.occupation,
+    status: raw.status ?? 'Ok',
+  }
+}
+
+async function handleFsAction(root: Root, params: URLSearchParams): Promise<Response> {
+  const action = params.get('action') ?? 'list'
+  const dir = params.get('path') ?? '/'
+  const filename = params.get('filename') ?? ''
+
+  try {
+    switch (action) {
+      case 'list':
+        break
+      case 'delete':
+        await fsRequest('delete', { root, path: joinPath(dir, filename) })
+        break
+      case 'deletedir':
+        await fsRequest('deletedir', { root, path: joinPath(dir, filename) })
+        break
+      case 'createdir':
+        await fsRequest('mkdir', { root, path: joinPath(dir, filename) })
+        break
+      // 'rename' isn't implemented -- no fluidnc_fs_rename() bridge
+      // function exists yet (same gap as WebUI-mm's wasmBridgeFileTransport
+      // .ts). Falls through to the default below.
+      default:
+        return errorResponse(`Unsupported file operation in wasm demo: ${action}`, 400)
+    }
+    const listing = await fsRequest('list', { root, path: dir })
+    return ok(JSON.stringify(reshapeListing(listing, dir)), 'application/json')
+  } catch (e) {
+    return errorResponse(String(e))
+  }
+}
+
+async function handleUpload(root: Root, params: URLSearchParams, body: FormData): Promise<Response> {
+  const dir = params.get('path') ?? '/'
+  const writes: Promise<unknown>[] = []
+  body.forEach((val, key) => {
+    if (key === 'myfile[]' && val instanceof File) {
+      writes.push(val.text().then((content) => fsRequest('write', { root, path: joinPath(dir, val.name), content })))
+    }
+  })
+  await Promise.all(writes)
+  const listing = await fsRequest('list', { root, path: dir })
+  return ok(JSON.stringify(reshapeListing(listing, dir)), 'application/json')
+}
+
+async function handleFileDownload(pathname: string): Promise<Response> {
+  const isSd = pathname === '/sd' || pathname.startsWith('/sd/')
+  const root: Root = isSd ? 'native_sd' : 'native_localfs'
+  const path = isSd ? pathname.slice(3) || '/' : pathname
+  try {
+    const content = await fsRequest('read', { root, path })
+    return ok(content as string)
+  } catch {
+    return new Response('Not found', { status: 404 })
+  }
+}
+
+export function installFetchInterceptor(): void {
+  const orig = window.fetch.bind(window)
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const href = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url
+    const extracted = extractRequestUrl(href)
+    if (!extracted) return orig(input, init)
+    const { pathname: p, searchParams } = extracted
+    const m = (init?.method ?? 'GET').toUpperCase()
+
+    if (p === '/command' || p === '/command_silent') {
+      const plain = searchParams.get('plain') ?? ''
+      try {
+        return ok(await sendBridgeCommand(plain))
+      } catch (e) {
+        return errorResponse(String(e))
+      }
+    }
+
+    if (p === '/upload' || p === '/files') {
+      const root = rootForPath(p)
+      if (m === 'POST' && init?.body instanceof FormData) {
+        return handleUpload(root, searchParams, init.body)
+      }
+      return handleFsAction(root, searchParams)
+    }
+
+    // /ext isn't backed by anything in the wasm build (no second SD-like
+    // mount exists there), so it's left unintercepted -- falls through to
+    // the original fetch, which will fail the same way an unhandled path
+    // would on real hardware with nothing mounted there.
+    if (p === '/sd' || p.startsWith('/sd/') || p.startsWith('/localfs/')) {
+      return handleFileDownload(p)
+    }
+
+    return orig(input, init)
+  }
+}
+
+// XHR intercept for uploadFile() (progress-tracked uploads) -- see
+// src/lib/http.ts. uploadFirmware() posts to /updatefw, which isn't
+// intercepted: there's no real flashing to simulate in a wasm demo, so it's
+// left to fail like any other unhandled path, same as demo mode leaves it.
+export function installXhrInterceptor(): void {
+  const Orig = window.XMLHttpRequest
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).XMLHttpRequest = function InterceptedXHR() {
+    const real = new Orig()
+    let intercept = false
+    let interceptRoot: Root = 'native_sd'
+    let storedOnload: ((e: ProgressEvent) => void) | null = null
+    const fakeUpload = { onprogress: null as ((e: ProgressEvent) => void) | null }
+
+    return new Proxy(real, {
+      get(target, prop) {
+        if (intercept && prop === 'status') return 200
+        if (intercept && prop === 'readyState') return 4
+        if (intercept && prop === 'upload') return fakeUpload
+
+        if (prop === 'open')
+          return (method: string, url: string | URL, ...rest: unknown[]) => {
+            // See extractRequestUrl()'s comment above -- same blob:-base
+            // and empty-window.location.host issues apply here.
+            const path = extractRequestUrl(String(url))?.pathname ?? ''
+            intercept = path === '/upload' || path === '/files'
+            interceptRoot = path === '/upload' ? 'native_sd' : 'native_localfs'
+            if (!intercept) real.open.call(real, method, url, ...(rest as [boolean, string?, string?]))
+          }
+
+        if (prop === 'send')
+          return (body?: unknown) => {
+            if (intercept) {
+              const fd = body instanceof FormData ? body : null
+              const writes: Promise<unknown>[] = []
+              if (fd) {
+                const dir = (fd.get('path') as string) ?? '/'
+                fd.forEach((val, key) => {
+                  if (key === 'myfile[]' && val instanceof File) {
+                    writes.push(
+                      val.text().then((content) => fsRequest('write', { root: interceptRoot, path: joinPath(dir, val.name), content }))
+                    )
+                  }
+                })
+              }
+              Promise.all(writes)
+                .catch(() => {})
+                .then(() => storedOnload?.(new ProgressEvent('load', { loaded: 100, total: 100 })))
+            } else {
+              real.send.call(real, body as XMLHttpRequestBodyInit | Document | null | undefined)
+            }
+          }
+
+        if (prop === 'setRequestHeader')
+          return (name: string, value: string) => {
+            if (!intercept) real.setRequestHeader.call(real, name, value)
+          }
+
+        if (prop === 'abort') return () => real.abort.call(real)
+
+        const val = Reflect.get(target, prop, target)
+        return typeof val === 'function' ? val.bind(target) : val
+      },
+
+      set(target, prop, value) {
+        if (intercept && prop === 'onload') {
+          storedOnload = value
+          return true
+        }
+        try {
+          Reflect.set(target, prop, value, target)
+        } catch {
+          /* read-only accessor */
+        }
+        return true
+      },
+    })
+  }
+}

--- a/src/wasmBridge/index.ts
+++ b/src/wasmBridge/index.ts
@@ -1,0 +1,23 @@
+import { isWasmBridgeActive } from './shimTransport'
+import { WasmBridgeWebSocket } from './WasmBridgeWebSocket'
+import { installFetchInterceptor, installXhrInterceptor } from './httpBridge'
+
+// Mirrors src/demo/index.ts's installDemoMode() (replace window.WebSocket,
+// intercept fetch/XHR), but gated on a runtime marker (see
+// shimTransport.ts's isWasmBridgeActive()) instead of the build-time
+// VITE_DEMO_MODE flag -- so a stock production build (e.g. `npm run
+// build:esp32`, the real firmware-deployment artifact) works unmodified
+// when loaded inside the FluidNC WASM demo's iframe, without needing a
+// special build mode of its own. Unlike demo mode, which fully simulates a
+// machine in JS, this talks to a real compiled FluidNC instance running in
+// WebAssembly, via postMessage -- see FluidNC/wasm/README.md.
+//
+// Called unconditionally from main.tsx (not behind an import.meta.env
+// check) so it survives tree-shaking in every build mode; it's a no-op
+// unless the runtime marker is present.
+export function installWasmBridgeIfActive(): void {
+  if (!isWasmBridgeActive()) return
+  ;(window as unknown as { WebSocket: unknown }).WebSocket = WasmBridgeWebSocket
+  installFetchInterceptor()
+  installXhrInterceptor()
+}

--- a/src/wasmBridge/shimTransport.ts
+++ b/src/wasmBridge/shimTransport.ts
@@ -1,0 +1,93 @@
+// Low-level postMessage client for the FluidNC WASM demo's bridge (see
+// FluidNC/wasm/README.md and demo/index.html's self.fluidncOnShimOutput /
+// 'fluidnc-shim-send' listener). This is the same protocol WebUI-mm's own
+// wasmBridgeTransport.ts speaks -- the demo page doesn't know or care which
+// WebUI is loaded in its iframe, so nothing on the FluidNC/demo side needed
+// to change for FigUI to use it too.
+//
+// Two message kinds share this one postMessage channel:
+//  - 'fluidnc-shim-line'/'fluidnc-shim-send': ShimChannel's Grbl-line
+//    protocol. demo/index.html buffers raw shim output into whole lines and
+//    reassembles [JSON:...]-encapsulated chunks (see FluidNC's JSONencoder
+//    -- a JSON payload sent out over a serial-shaped channel is wrapped
+//    that way so a payload line can never be mistaken for the ok/error
+//    line that terminates a command) itself before ever posting a line
+//    here, so this module just relays whole, already-unwrapped lines to
+//    listeners -- matching what FigUI's own code already expects to see
+//    from real hardware's WebSocket (WSChannel doesn't use that wrapping --
+//    see WebCommands.cpp/ShimChannel.cpp).
+//  - 'fluidnc-fs-request'/'fluidnc-fs-response': a request/response RPC for
+//    file operations, answered directly against the WASM instance's MEMFS
+//    (list/delete/deletedir/mkdir/read/write) -- see demo/index.html's
+//    handleFsRequest().
+
+type LineListener = (line: string, isJson: boolean) => void
+
+interface FsResponse {
+  type: 'fluidnc-fs-response'
+  id: number
+  ok: boolean
+  result?: unknown
+}
+
+const lineListeners: LineListener[] = []
+const pendingFsRequests = new Map<number, { resolve: (result: unknown) => void; reject: (error: Error) => void }>()
+let nextRequestId = 1
+
+// Set by a marker <script> the demo injects ahead of the actual page
+// content before Blob-constructing the iframe's document -- see
+// demo/index.html's webuiSelect handler / loadWebuiHtml().
+export function isWasmBridgeActive(): boolean {
+  return typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__FLUIDNC_WASM_BRIDGE__ === true
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('message', (event: MessageEvent) => {
+    // The demo page is the only legitimate sender -- postMessage's
+    // targetOrigin is '*' on both ends (this document is loaded from a
+    // blob: URL with no fixed origin to pin to), so checking the source
+    // window is the only authenticity check available.
+    if (event.source !== window.parent) return
+    const msg = event.data
+    if (msg && msg.type === 'fluidnc-shim-line' && typeof msg.line === 'string') {
+      lineListeners.forEach((fn) => fn(msg.line, !!msg.isJson))
+    } else if (msg && msg.type === 'fluidnc-fs-response' && typeof msg.id === 'number') {
+      const response = msg as FsResponse
+      const pending = pendingFsRequests.get(response.id)
+      if (!pending) return
+      pendingFsRequests.delete(response.id)
+      if (response.ok) {
+        pending.resolve(response.result)
+      } else {
+        pending.reject(new Error(typeof response.result === 'string' ? response.result : 'File operation failed'))
+      }
+    }
+  })
+}
+
+export function sendToShim(text: string): void {
+  window.parent.postMessage({ type: 'fluidnc-shim-send', text }, '*')
+}
+
+// isJson is true exactly when `line` is a fully reassembled [JSON:...]
+// payload (brackets already stripped, chunks concatenated) rather than a
+// normal protocol line -- callers should never need to sniff line content
+// to tell the two apart.
+export function addShimLineListener(fn: LineListener): () => void {
+  lineListeners.push(fn)
+  return () => {
+    const i = lineListeners.indexOf(fn)
+    if (i >= 0) lineListeners.splice(i, 1)
+  }
+}
+
+// root is "native_sd" or "native_localfs"; path is POSIX-absolute-style
+// ("/", "/sub/file.nc"), matching what demo/index.html's handleFsRequest
+// (and the C++ fluidnc_fs_* bridge functions it calls) expect.
+export function fsRequest(op: string, params: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = nextRequestId++
+    pendingFsRequests.set(id, { resolve, reject })
+    window.parent.postMessage({ type: 'fluidnc-fs-request', id, op, ...params }, '*')
+  })
+}

--- a/src/wasmBridge/shimTransport.ts
+++ b/src/wasmBridge/shimTransport.ts
@@ -20,6 +20,14 @@
 //    file operations, answered directly against the WASM instance's MEMFS
 //    (list/delete/deletedir/mkdir/read/write) -- see demo/index.html's
 //    handleFsRequest().
+//  - 'fluidnc-shim-command'/'fluidnc-shim-command-response': send a
+//    command, get back its collected response once the ok/error terminator
+//    arrives -- see demo/index.html's deliverShimLine()/
+//    maybeStartNextShimCommand(), which also queues these so two in flight
+//    at once can't have their response lines cross-attributed (this used
+//    to be commandBridge.ts's own job, via a hand-rolled line collector and
+//    a Promise chain to serialize sends -- both gone now that
+//    demo/index.html does it centrally for every WebUI bridge).
 
 type LineListener = (line: string, isJson: boolean) => void
 
@@ -30,9 +38,19 @@ interface FsResponse {
   result?: unknown
 }
 
+interface ShimCommandResponse {
+  type: 'fluidnc-shim-command-response'
+  id: number
+  ok: boolean
+  response: string
+  ackLine: string
+}
+
 const lineListeners: LineListener[] = []
 const pendingFsRequests = new Map<number, { resolve: (result: unknown) => void; reject: (error: Error) => void }>()
+const pendingShimCommands = new Map<number, { resolve: (response: string) => void; reject: (error: Error) => void }>()
 let nextRequestId = 1
+let nextCommandId = 1
 
 // Set by a marker <script> the demo injects ahead of the actual page
 // content before Blob-constructing the iframe's document -- see
@@ -51,6 +69,16 @@ if (typeof window !== 'undefined') {
     const msg = event.data
     if (msg && msg.type === 'fluidnc-shim-line' && typeof msg.line === 'string') {
       lineListeners.forEach((fn) => fn(msg.line, !!msg.isJson))
+    } else if (msg && msg.type === 'fluidnc-shim-command-response' && typeof msg.id === 'number') {
+      const response = msg as ShimCommandResponse
+      const pending = pendingShimCommands.get(response.id)
+      if (!pending) return
+      pendingShimCommands.delete(response.id)
+      if (response.ok) {
+        pending.resolve(response.response)
+      } else {
+        pending.reject(new Error(response.ackLine))
+      }
     } else if (msg && msg.type === 'fluidnc-fs-response' && typeof msg.id === 'number') {
       const response = msg as FsResponse
       const pending = pendingFsRequests.get(response.id)
@@ -67,6 +95,19 @@ if (typeof window !== 'undefined') {
 
 export function sendToShim(text: string): void {
   window.parent.postMessage({ type: 'fluidnc-shim-send', text }, '*')
+}
+
+// Sends a command and resolves with its collected response once the
+// ok/error terminator line arrives -- see demo/index.html's
+// deliverShimLine()/maybeStartNextShimCommand(), which also queues these
+// centrally so concurrent sends can't have their response lines
+// cross-attributed over the bridge's one shared channel.
+export function sendShimCommand(cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const id = nextCommandId++
+    pendingShimCommands.set(id, { resolve, reject })
+    window.parent.postMessage({ type: 'fluidnc-shim-command', id, cmd }, '*')
+  })
 }
 
 // isJson is true exactly when `line` is a fully reassembled [JSON:...]


### PR DESCRIPTION
## Summary
Lets FigUI run against a real, compiled FluidNC instance running in WebAssembly in the browser (see `FluidNC/wasm/README.md` in the firmware repo), instead of only real hardware or the JS-simulated demo mode. `wasmBridge/index.ts`'s `installWasmBridgeIfActive()` is called unconditionally from `main.tsx` (works in every build mode, including the real `build:esp32` artifact) and is a no-op unless a runtime marker is present, so it's harmless in a normal deployment — the marker only gets injected when this build is loaded inside the FluidNC WASM demo's iframe.

- `wasmBridge/shimTransport.ts` — low-level `postMessage` client talking to the demo page's `ShimChannel` bridge (raw Grbl-line stream + a file-op request/response RPC).
- `wasmBridge/WasmBridgeWebSocket.ts` — installed as `window.WebSocket` so `src/lib/ws.ts` works unmodified.
- `wasmBridge/httpBridge.ts` — intercepts `fetch`/`XMLHttpRequest` for `/command`, `/upload`, `/files`, etc., matching `src/lib/http.ts`'s real endpoints.
- `wasmBridge/commandBridge.ts` — request/response command sends for the HTTP-shaped surface.

Since the wasm build shares one physical channel for everything (unlike real hardware's genuinely independent HTTP and WebSocket connections), the last two commits close a couple of races that only show up in that environment:

- **JSON reassembly moved to common code**: FluidNC's `JSONencoder` wraps JSON payloads sent over a serial-shaped channel in `[JSON:...]`-tagged chunks, so a payload line can't collide with the `ok`/`error` line that terminates a command. That reassembly used to be done independently in this bridge and in the equivalent bridges for two other WebUI projects (ESP3D-WEBUI, WebUI-mm) that talk to the same demo. It's now done once, by the demo page itself, before anything is ever posted here — this bridge just receives whole, already-unwrapped lines.
- **Centralized command queuing**: two commands sent through the bridge at once could have their response lines cross-attributed. Fixed by queuing sends centrally on the demo side rather than per-bridge. A real bug surfaced during testing: a raw send made directly through `WasmBridgeWebSocket` (bypassing the old per-bridge queue) could still race a pending command and steal its `ok` line, so the queue now serializes *all* shim traffic — raw sends and RPC commands alike — not just commands against each other.
- **Real ESP800 instead of a spoofed response**: the wasm build now has an actual `[ESP800]json=yes` handler (`FluidNC/wasm/FwInfo.cpp` in the firmware repo) rather than each bridge hardcoding a fake firmware-info response — `parser.ts`/`App.tsx`/`http.ts` updated to consume the real JSON shape.

## Note for reviewers
`src/lib/http.ts` overlaps with `e4d3cec` (Serialize filesystem ops), already on `main`. This branch predates that commit, so it doesn't yet reflect it — both efforts independently added serialization to prevent races in their own subsystem (filesystem ops there, shim commands here), just worth being aware of when merging. The overlapping line (`getDeviceInfoFast`'s `[ESP800]` command string) isn't touched by `e4d3cec` itself, so I don't expect a real conflict, but flagging it since I haven't rebased onto current `main` yet.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build:esp32` clean
- [x] Verified live against the FluidNC WASM demo: boots, shows live machine status, Settings/Machine Config panels populate from real ESP400/ESP401/ESP800 data, file manager works
- [ ] Rebase onto current `main` and re-verify (12 commits behind at the time of this PR)
- [ ] Manual smoke test on real hardware to confirm the bridge is inert (marker check short-circuits) in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)